### PR TITLE
fix: Package exports for `esm` CDN

### DIFF
--- a/packages/nodebox/package.json
+++ b/packages/nodebox/package.json
@@ -3,7 +3,15 @@
   "version": "0.0.39",
   "description": "Public API of Nodebox",
   "main": "./build/index.js",
+  "module": "./build/index.mjs",
   "typings": "./build/index.d.ts",
+  "exports": {
+    "/": {
+      "import": "./build/index.mjs",
+      "require": "./build/index.js",
+      "types": "./build/index.d.ts"
+    }
+  },
   "license": "SEE LICENSE IN ./LICENSE",
   "files": [
     "./build"

--- a/packages/nodebox/package.json
+++ b/packages/nodebox/package.json
@@ -6,7 +6,7 @@
   "module": "./build/index.mjs",
   "typings": "./build/index.d.ts",
   "exports": {
-    "/": {
+    ".": {
       "import": "./build/index.mjs",
       "require": "./build/index.js",
       "types": "./build/index.d.ts"


### PR DESCRIPTION
Yesterday i was trying to put together a `svelte` component using CDN using `@codesandbox/sandpack-client`. But turns out it is using `PREVIEW_LOADED_MESSAGE_TYPE` from `@codesandbox/nodebox`.

The package is  currently building both `esm` and `cjs`. But, mainly exposing `cjs` alone in `package.json` field. So, When the CDN's which stricly follow `esm` spec fails to load the `PREVIEW_LOADED_MESSAGE_TYPE` because it's a `namesExport` in `cjs` which is trying to parse it back to `esm` to distribute.  So, this just exposes `esm` file path to those CDN's.

Adding `exports` will encapsulate the full path imports now. SO, if there is any use case where users need to use imports like
`@codesandbox/nodebox/build/<some-file`. Please let me know i can add it to the `exports` field. 

Error repos
https://jspm.org/sandbox#H4sIAAAAAAAAA41U21LbMBB95ysW9wXa2E5oaWlwMuGSYZohQ4tJW/qmyBsskCUjySFph3+vLDuBZCDtgy1rL2fPrnc32k4kNfMcITUZ725FiwNJ0t0CiDI0BGhKlEbT8Qoz8Q88pzDMcOyOhDuTKKzuSxdBMux4U4YPuVTGAyqFQWEhHlhi0k6CU0bRd5cGMMEMI9zXlHDstGyAKKwYRGOZzB3qtu/bA2AQfx3CGQpUxEgFX7ISH4Ykd9p+wgyMLs/bNh+T63YY3ixMg1udZwGT4ZvR3vf0+uz47nTYVPP49yAetVLav724at6ZKz07j+n9tHk0uTy+FoO9sRpc/MpyjEcXl0KeYXF99LO1/+3jaf/IRvR9R05TxXIDZSE7HnOUMpK7Qv1xvGqh9tq1wIp6VCaoiUjGchaWZ07onU85s3Wydt4yA7KkLvKsvcmttxc0g09hwrQJmUhwFmS32nMBHxsVEU1ljis8XojzTL1OVNhve/4vwdq81wxaQTMcF4wnNTNLrPEU45mPX9XKLwzjOuRsHFKFxKC/wDSY5dwK9AYSr+H1WsH74GAj6hozLhOi04BpvC8I3xBy1bD3Idi3Gb+UqyzMlChGNv7mJyNHuekoL9FqsMetxbt8orDqw7Lt6pGBfgxDmRQcIU5ZptuLgbHtqSGXfD5hnMPETlLmzDSMlXzQqDQ8MJNaFsCeeegid5cdYr1wRtF2/UmqZIZw8Pnd7to8ED0XFLSindeyRO1XcX1d0rOp7getqn/XVGXWQJXUWip2w0THI0KKeSYL7XXXM1+ZxwrFDSMsknlruUFcD8+Jmx2Y2DT+MZWHFT5AGMIPxQzaqjBRlw5KT0hRYQNsPW0AAhpzYrcPgi0zuopaoWcr4gExRrFxYXVSgElxgVJxD1wYuzW15BhwebOzynb3cOWHR2G1KO3edAv8L0acfrfYBQAA

Auto generated exports field
https://ga.jspm.io/npm:@codesandbox/nodebox@0.1.0/package.json